### PR TITLE
FEATURE: Implement Pollutant Management

### DIFF
--- a/src/main/java/com/misight/controller/MonitoringStationController.java
+++ b/src/main/java/com/misight/controller/MonitoringStationController.java
@@ -1,0 +1,65 @@
+package com.misight.controller;
+
+import com.misight.model.MonitoringStation;
+import com.misight.service.MonitoringStationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/stations")
+public class MonitoringStationController {
+
+    private final MonitoringStationService stationService;
+
+    @Autowired
+    public MonitoringStationController(MonitoringStationService stationService) {
+        this.stationService = stationService;
+    }
+
+    @PostMapping
+    public ResponseEntity<MonitoringStation> createStation(@RequestBody MonitoringStation station) {
+        MonitoringStation addedStation = stationService.addStation(station);
+        return new ResponseEntity<>(addedStation, HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public List<MonitoringStation> getStations() {
+        return stationService.getAllStations();
+    }
+
+    @GetMapping("/{station_id}")
+    public Optional<MonitoringStation> getStationById(@PathVariable("station_id") Integer station_id) {
+        return stationService.getStationById(station_id);
+    }
+
+    @GetMapping("/province/{province_id}")
+    public List<MonitoringStation> getStationsByProvince(@PathVariable("province_id") Integer province_id) {
+        return stationService.getStationsByProvince(province_id);
+    }
+
+    @DeleteMapping("/{station_id}")
+    public boolean deleteStation(@PathVariable("station_id") Integer station_id) {
+        if (!stationService.findById(station_id).equals(Optional.empty())) {
+            stationService.delStation(station_id);
+            return true;
+        }
+        return false;
+    }
+
+    @PutMapping("/{station_id}")
+    public MonitoringStation updateStation(@PathVariable("station_id") Integer station_id,
+                                           @RequestBody Map<String, String> body) {
+        MonitoringStation currentStation = stationService.getStationById(station_id).get();
+        currentStation.setStation_name(body.get("station_name"));
+        currentStation.setLocation(body.get("location"));
+        currentStation.setProvince_id(Integer.parseInt(body.get("province_id")));
+
+        stationService.addStation(currentStation);
+        return currentStation;
+    }
+}

--- a/src/main/java/com/misight/controller/PollutantController.java
+++ b/src/main/java/com/misight/controller/PollutantController.java
@@ -1,0 +1,60 @@
+package com.misight.controller;
+
+import com.misight.model.Pollutant;
+import com.misight.service.PollutantService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/pollutants")
+public class PollutantController {
+
+    private final PollutantService pollutantService;
+
+    @Autowired
+    public PollutantController(PollutantService pollutantService) {
+        this.pollutantService = pollutantService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Pollutant> createPollutant(@RequestBody Pollutant pollutant) {
+        Pollutant addedPollutant = pollutantService.addPollutant(pollutant);
+        return new ResponseEntity<>(addedPollutant, HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public List<Pollutant> getPollutants() {
+        return pollutantService.getAllPollutants();
+    }
+
+    @GetMapping("/{pollutant_id}")
+    public Optional<Pollutant> getPollutantById(@PathVariable("pollutant_id") Integer pollutant_id) {
+        return pollutantService.getPollutantById(pollutant_id);
+    }
+
+    @DeleteMapping("/{pollutant_id}")
+    public boolean deletePollutant(@PathVariable("pollutant_id") Integer pollutant_id) {
+        if (!pollutantService.findById(pollutant_id).equals(Optional.empty())) {
+            pollutantService.delPollutant(pollutant_id);
+            return true;
+        }
+        return false;
+    }
+
+    @PutMapping("/{pollutant_id}")
+    public Pollutant updatePollutant(@PathVariable("pollutant_id") Integer pollutant_id,
+                                     @RequestBody Map<String, String> body) {
+        Pollutant currentPollutant = pollutantService.getPollutantById(pollutant_id).get();
+        currentPollutant.setPollutant_name(body.get("pollutant_name"));
+        currentPollutant.setUnit(body.get("unit"));
+        currentPollutant.setDescription(body.get("description"));
+
+        pollutantService.addPollutant(currentPollutant);
+        return currentPollutant;
+    }
+}

--- a/src/main/java/com/misight/model/MonitoringStation.java
+++ b/src/main/java/com/misight/model/MonitoringStation.java
@@ -1,4 +1,66 @@
 package com.misight.model;
 
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "monitoring_stations")
 public class MonitoringStation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int station_id;
+
+    @Column(nullable = false)
+    private String station_name;
+
+    @Column(nullable = false)
+    private String location;
+
+    @Column(nullable = false)
+    private int province_id;
+
+    public MonitoringStation() {}
+
+    public MonitoringStation(String station_name, String location, int province_id) {
+        this.station_name = station_name;
+        this.location = location;
+        this.province_id = province_id;
+    }
+
+    public int getStation_id() {
+        return station_id;
+    }
+
+    public String getStation_name() {
+        return station_name;
+    }
+
+    public void setStation_name(String station_name) {
+        this.station_name = station_name;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public int getProvince_id() {
+        return province_id;
+    }
+
+    public void setProvince_id(int province_id) {
+        this.province_id = province_id;
+    }
+
+    @Override
+    public String toString() {
+        return "MonitoringStation{" +
+                "station_id=" + station_id +
+                ", station_name='" + station_name + '\'' +
+                ", location='" + location + '\'' +
+                ", province_id=" + province_id +
+                '}';
+    }
 }

--- a/src/main/java/com/misight/model/Pollutant.java
+++ b/src/main/java/com/misight/model/Pollutant.java
@@ -1,4 +1,68 @@
 package com.misight.model;
 
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "pollutants")
 public class Pollutant {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int pollutant_id;
+
+    @Column(nullable = false)
+    private String pollutant_name;
+
+    @Column(nullable = false)
+    private String unit;
+
+    @Column
+    private String description;
+
+    public Pollutant() {}
+
+    public Pollutant(String pollutant_name, String unit, String description) {
+        this.pollutant_name = pollutant_name;
+        this.unit = unit;
+        this.description = description;
+    }
+
+    // Getters
+    public int getPollutant_id() {
+        return pollutant_id;
+    }
+
+    public String getPollutant_name() {
+        return pollutant_name;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    // Setters
+    public void setPollutant_name(String pollutant_name) {
+        this.pollutant_name = pollutant_name;
+    }
+
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String toString() {
+        return "Pollutant{" +
+                "pollutant_id=" + pollutant_id +
+                ", pollutant_name='" + pollutant_name + '\'' +
+                ", unit='" + unit + '\'' +
+                ", description='" + description + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/com/misight/repository/MonitoringStationRepo.java
+++ b/src/main/java/com/misight/repository/MonitoringStationRepo.java
@@ -1,0 +1,11 @@
+package com.misight.repository;
+
+import com.misight.model.MonitoringStation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface MonitoringStationRepo extends JpaRepository<MonitoringStation, Integer> {
+    List<MonitoringStation> findByProvinceId(Integer province_id);
+}

--- a/src/main/java/com/misight/repository/PollutantRepo.java
+++ b/src/main/java/com/misight/repository/PollutantRepo.java
@@ -1,0 +1,11 @@
+package com.misight.repository;
+
+import com.misight.model.Pollutant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+@Repository
+public interface PollutantRepo extends JpaRepository<Pollutant, Integer> {
+    Optional<Pollutant> findByPollutantName(String pollutant_name);
+}

--- a/src/main/java/com/misight/service/MonitoringStationService.java
+++ b/src/main/java/com/misight/service/MonitoringStationService.java
@@ -1,0 +1,42 @@
+package com.misight.service;
+
+import com.misight.model.MonitoringStation;
+import com.misight.repository.MonitoringStationRepo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class MonitoringStationService {
+    private final MonitoringStationRepo stationRepo;
+
+    @Autowired
+    public MonitoringStationService(MonitoringStationRepo stationRepo) {
+        this.stationRepo = stationRepo;
+    }
+
+    public MonitoringStation addStation(MonitoringStation station) {
+        return stationRepo.save(station);
+    }
+
+    public List<MonitoringStation> getAllStations() {
+        return stationRepo.findAll();
+    }
+
+    public Optional<MonitoringStation> getStationById(Integer station_id) {
+        return stationRepo.findById(station_id);
+    }
+
+    public List<MonitoringStation> getStationsByProvince(Integer province_id) {
+        return stationRepo.findByProvinceId(province_id);
+    }
+
+    public void delStation(Integer station_id) {
+        stationRepo.deleteById(station_id);
+    }
+
+    public Optional<MonitoringStation> findById(Integer station_id) {
+        return stationRepo.findById(station_id);
+    }
+}

--- a/src/main/java/com/misight/service/PollutantService.java
+++ b/src/main/java/com/misight/service/PollutantService.java
@@ -1,0 +1,42 @@
+package com.misight.service;
+
+import com.misight.model.Pollutant;
+import com.misight.repository.PollutantRepo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class PollutantService {
+    private final PollutantRepo pollutantRepo;
+
+    @Autowired
+    public PollutantService(PollutantRepo pollutantRepo) {
+        this.pollutantRepo = pollutantRepo;
+    }
+
+    public Pollutant addPollutant(Pollutant pollutant) {
+        return pollutantRepo.save(pollutant);
+    }
+
+    public List<Pollutant> getAllPollutants() {
+        return pollutantRepo.findAll();
+    }
+
+    public Optional<Pollutant> getPollutantById(Integer pollutant_id) {
+        return pollutantRepo.findById(pollutant_id);
+    }
+
+    public Optional<Pollutant> findById(Integer pollutant_id) {
+        return pollutantRepo.findById(pollutant_id);
+    }
+
+    public void delPollutant(Integer pollutant_id) {
+        pollutantRepo.deleteById(pollutant_id);
+    }
+
+    public Optional<Pollutant> findByPollutantName(String pollutant_name) {
+        return pollutantRepo.findByPollutantName(pollutant_name);
+    }
+}


### PR DESCRIPTION
- Add Pollutant model with JPA mappings
- Create PollutantRepo with name query support
- Implement PollutantService with CRUD operations
- Add REST controller with full API endpoints
- Support pollutant type management for environmental monitoring

Implements pollutant tracking requirements including:
- Pollutant definition and updates
- Unit management
- Description tracking
- Full CRUD REST API endpoints